### PR TITLE
MNT: Add setuptools as build dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
     - numpy
 
   run:


### PR DESCRIPTION
Setup tools is needed as a build dependency to use the current build command:

```
python setup.py install --single-version-externally-managed --record=record.txt
```

This should fix the problems with #2 
